### PR TITLE
Bugfix/prot 46 login timeout when server is not running

### DIFF
--- a/client/app/src/main/java/com/example/protego/DoctorDashboardActivity.java
+++ b/client/app/src/main/java/com/example/protego/DoctorDashboardActivity.java
@@ -12,6 +12,7 @@ import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
 import android.widget.Button;
 import android.widget.Spinner;
+import android.widget.Toast;
 
 import com.example.protego.web.ServerAPI;
 import com.example.protego.web.ServerRequest;
@@ -70,7 +71,7 @@ public class DoctorDashboardActivity extends AppCompatActivity{
     private void getDoctorInfo(String duid) {
         ServerAPI.getDoctor(duid, new ServerRequestListener() {
             @Override
-            public void recieveCompletedRequest(ServerRequest req) {
+            public void receiveCompletedRequest(ServerRequest req) {
                 if (req != null && !req.getResultString().equals("")) {
                     Log.d(TAG, "req recieved for doctor : " + req.getResult().toString());
 
@@ -86,6 +87,11 @@ public class DoctorDashboardActivity extends AppCompatActivity{
                 } else {
                     Log.d(TAG, "failed to get doctor : " + req.toString());
                 }
+            }
+
+            @Override
+            public void receiveError(Exception e, String msg) {
+                Toast.makeText(DoctorDashboardActivity.this, msg, Toast.LENGTH_LONG);
             }
         });
     }

--- a/client/app/src/main/java/com/example/protego/DoctorViewPatientsActivity.java
+++ b/client/app/src/main/java/com/example/protego/DoctorViewPatientsActivity.java
@@ -7,6 +7,7 @@ import android.os.Bundle;
 import android.util.Log;
 import android.view.View;
 import android.widget.Button;
+import android.widget.Toast;
 
 import com.example.protego.web.ServerAPI;
 import com.example.protego.web.ServerRequest;
@@ -42,7 +43,7 @@ public class DoctorViewPatientsActivity extends AppCompatActivity {
     private void getPatients() {
         ServerAPI.getDoctorAssignedPatients(mAuth.getCurrentUser().getUid(), new ServerRequestListener() {
             @Override
-            public void recieveCompletedRequest(ServerRequest req) {
+            public void receiveCompletedRequest(ServerRequest req) {
                 Log.d(TAG, "Received request for doctor's patients");
                 try {
                     JSONArray res = req.getResultJSONList();
@@ -51,6 +52,11 @@ public class DoctorViewPatientsActivity extends AppCompatActivity {
                 } catch (JSONException e) {
                     e.printStackTrace();
                 }
+            }
+
+            @Override
+            public void receiveError(Exception e, String msg) {
+                Toast.makeText(DoctorViewPatientsActivity.this, msg, Toast.LENGTH_LONG);
             }
         });
     }

--- a/client/app/src/main/java/com/example/protego/PatientDashboardActivity.java
+++ b/client/app/src/main/java/com/example/protego/PatientDashboardActivity.java
@@ -12,6 +12,7 @@ import android.widget.Button;
 import android.widget.ImageButton;
 import android.widget.LinearLayout;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import com.example.protego.web.ServerAPI;
 import com.example.protego.web.ServerRequest;
@@ -81,7 +82,7 @@ public class PatientDashboardActivity extends AppCompatActivity{
 
         ServerAPI.getPatient(currentUser.getUid(), new ServerRequestListener() {
             @Override
-            public void recieveCompletedRequest(ServerRequest req) {
+            public void receiveCompletedRequest(ServerRequest req) {
                 if (req != null && !req.getResultString().equals("")) {
                     Log.d(TAG, "req recieved for patient : " + req.getResult().toString());
 
@@ -97,11 +98,16 @@ public class PatientDashboardActivity extends AppCompatActivity{
                     Log.d(TAG, "Can't get patient info.");
                 }
             }
+
+            @Override
+            public void receiveError(Exception e, String msg) {
+                Toast.makeText(PatientDashboardActivity.this, msg, Toast.LENGTH_LONG);
+            }
         });
 
         ServerAPI.getMedication(currentUser.getUid(), new ServerRequestListener() {
             @Override
-            public void recieveCompletedRequest(ServerRequest req) {
+            public void receiveCompletedRequest(ServerRequest req) {
                 try {
                     JSONObject res = req.getResultJSON();
                     patientDetails.heartRate = res.getInt("heartRate");
@@ -118,6 +124,11 @@ public class PatientDashboardActivity extends AppCompatActivity{
                 } catch (JSONException e) {
                     Log.e(TAG, "Could not get JSON from request : ", e);
                 }
+            }
+
+            @Override
+            public void receiveError(Exception e, String msg) {
+                Toast.makeText(PatientDashboardActivity.this, msg, Toast.LENGTH_LONG);
             }
         });
       

--- a/client/app/src/main/java/com/example/protego/SignupActivity.java
+++ b/client/app/src/main/java/com/example/protego/SignupActivity.java
@@ -152,8 +152,13 @@ public class SignupActivity extends AppCompatActivity implements AdapterView.OnI
                                             if (last_name_input == null) {
                                                 ServerAPI.generateMedData(uid, new ServerRequestListener() {
                                                     @Override
-                                                    public void recieveCompletedRequest(ServerRequest req) {
+                                                    public void receiveCompletedRequest(ServerRequest req) {
                                                         // do nothing, just generate data
+                                                    }
+
+                                                    @Override
+                                                    public void receiveError(Exception e, String msg) {
+                                                        Toast.makeText(SignupActivity.this, msg, Toast.LENGTH_LONG);
                                                     }
                                                 });
                                             }

--- a/client/app/src/main/java/com/example/protego/web/RequestListener.java
+++ b/client/app/src/main/java/com/example/protego/web/RequestListener.java
@@ -2,4 +2,5 @@ package com.example.protego.web;
 
 public interface RequestListener<T> {
     public void getResult(T object);
+    public void getError(Exception e, String msg);
 }

--- a/client/app/src/main/java/com/example/protego/web/RequestManager.java
+++ b/client/app/src/main/java/com/example/protego/web/RequestManager.java
@@ -4,9 +4,14 @@ import android.content.Context;
 import android.util.Log;
 
 import com.android.volley.AuthFailureError;
+import com.android.volley.NetworkError;
+import com.android.volley.NoConnectionError;
+import com.android.volley.ParseError;
 import com.android.volley.Request;
 import com.android.volley.RequestQueue;
 import com.android.volley.Response;
+import com.android.volley.ServerError;
+import com.android.volley.TimeoutError;
 import com.android.volley.VolleyError;
 import com.android.volley.VolleyLog;
 import com.android.volley.toolbox.JsonObjectRequest;
@@ -73,12 +78,26 @@ public class RequestManager {
                     @Override
                     public void onErrorResponse(VolleyError error) {
                         // Failed to make the request
-                        if (null != error.networkResponse)
-                        {
-                            Log.d(TAG + ": ", "Error Response code: " + error.networkResponse.statusCode);
-                            Log.e(TAG, "Error request : ", error);
-                            listener.getResult(null);
+                        String message = null;
+                        if (error instanceof NetworkError) {
+                            message = "Cannot connect to Internet...Please check your connection!";
+                        } else if (error instanceof ServerError) {
+                            message = "The server could not be found. Please try again after some time!!";
+                        } else if (error instanceof AuthFailureError) {
+                            message = "Cannot connect to Internet...Please check your connection!";
+                        } else if (error instanceof ParseError) {
+                            message = "Parsing error! Please try again after some time!!";
+                        } else if (error instanceof NoConnectionError) {
+                            message = "Cannot connect to Internet...Please check your connection!";
+                        } else if (error instanceof TimeoutError) {
+                            message = "Connection TimeOut! Please check your internet connection.";
                         }
+
+                        if (error.networkResponse != null) {
+                            Log.d(TAG + ": ", "Error Response code: " + error.networkResponse.statusCode);
+                        }
+                        Log.e(TAG, "Error request : ", error);
+                        listener.getError(error, message);
                     }
                 }) {
                     @Override
@@ -115,12 +134,26 @@ public class RequestManager {
                     @Override
                     public void onErrorResponse(VolleyError error) {
                         // Failed to make the request
-                        if (null != error.networkResponse)
-                        {
+                        String message = null;
+                        if (error instanceof NetworkError) {
+                            message = "Cannot connect to Internet...Please check your connection!";
+                        } else if (error instanceof ServerError) {
+                            message = "The server could not be found. Please try again after some time!!";
+                        } else if (error instanceof AuthFailureError) {
+                            message = "Cannot connect to Internet...Please check your connection!";
+                        } else if (error instanceof ParseError) {
+                            message = "Parsing error! Please try again after some time!!";
+                        } else if (error instanceof NoConnectionError) {
+                            message = "Cannot connect to Internet...Please check your connection!";
+                        } else if (error instanceof TimeoutError) {
+                            message = "Connection TimeOut! Please check your internet connection.";
+                        }
+
+                        if (error.networkResponse != null) {
                             Log.d(TAG + ": ", "Error Response code: " + error.networkResponse.statusCode);
                         }
                         Log.e(TAG, "Error request : ", error);
-                        listener.getResult(null);
+                        listener.getError(error, message);
                     }
                 });
         queue.add(request);

--- a/client/app/src/main/java/com/example/protego/web/ServerRequest.java
+++ b/client/app/src/main/java/com/example/protego/web/ServerRequest.java
@@ -1,7 +1,5 @@
 package com.example.protego.web;
 
-import android.util.Log;
-
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -36,7 +34,12 @@ public class ServerRequest {
                         public void getResult(String object) {
                             setResult(object.toString());
                             completed = true;
-                            serverRequestListener.recieveCompletedRequest(thisRequest);
+                            serverRequestListener.receiveCompletedRequest(thisRequest);
+                        }
+
+                        @Override
+                        public void getError(Exception e, String msg) {
+                            serverRequestListener.receiveError(e, msg);
                         }
                     });
     }
@@ -57,7 +60,12 @@ public class ServerRequest {
                     public void getResult(String object) {
                         setResult(object);
                         completed = true;
-                        serverRequestListener.recieveCompletedRequest(thisRequest);
+                        serverRequestListener.receiveCompletedRequest(thisRequest);
+                    }
+
+                    @Override
+                    public void getError(Exception e, String msg) {
+                        serverRequestListener.receiveError(e, msg);
                     }
                 });
     }

--- a/client/app/src/main/java/com/example/protego/web/ServerRequestListener.java
+++ b/client/app/src/main/java/com/example/protego/web/ServerRequestListener.java
@@ -3,5 +3,6 @@ package com.example.protego.web;
 import org.json.JSONException;
 
 public interface ServerRequestListener {
-    public void recieveCompletedRequest(ServerRequest req);
+    public void receiveCompletedRequest(ServerRequest req);
+    public void receiveError(Exception e, String msg);
 }


### PR DESCRIPTION
Fix login timeout when the server is not running so that the patient remains on their dashboard without being booted back to the login page.